### PR TITLE
Add windows support removing linux support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,6 +3,7 @@ workspace(name = "com_limdor_rules_qt")
 new_local_repository(
     name = "qt",
     build_file = "@com_limdor_rules_qt//:qt.BUILD",
-    # path = "/usr/include/qt",  # arch linux
-    path = "/usr/include/x86_64-linux-gnu/qt5",  # debian
+    # path = "/usr/include/qt",  # arch linux (not supported)
+    # path = "/usr/include/x86_64-linux-gnu/qt5",  # debian (not supported)
+    path = "C:\\Qt\\5.9.9\\msvc2015_64\\", # windows
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,8 +1,8 @@
-workspace(name = "com_justbuchanan_rules_qt")
+workspace(name = "com_limdor_rules_qt")
 
 new_local_repository(
     name = "qt",
-    build_file = "@com_justbuchanan_rules_qt//:qt.BUILD",
+    build_file = "@com_limdor_rules_qt//:qt.BUILD",
     # path = "/usr/include/qt",  # arch linux
     path = "/usr/include/x86_64-linux-gnu/qt5",  # debian
 )

--- a/qt.BUILD
+++ b/qt.BUILD
@@ -1,117 +1,73 @@
-package(default_visibility = ["//visibility:public"])
+load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
 
-cc_library(
-    name = "qt_core",
-    hdrs = glob(["QtCore/**"]),
-    includes = ["."],
-    linkopts = [
-        "-lQt5Core",
-    ],
+cc_import(
+    name = "qt_core_private",
+    hdrs = glob(["include/QtCore/**"]),
+    interface_library = "lib/Qt5Core.lib",
+    shared_library = "bin/Qt5Core.dll",
 )
 
 cc_library(
-    name = "qt_network",
-    hdrs = glob(["QtNetwork/**"]),
-    includes = ["."],
-    linkopts = [
-        "-lQt5Network",
-    ],
+    name = "qt_core",
+    hdrs = glob(["include/QtCore/**"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [":qt_core_private"],
+)
+
+cc_import(
+    name = "qt_widgets_private",
+    hdrs = glob(["include/QtWidgets/**"]),
+    interface_library = "lib/Qt5Widgets.lib",
+    shared_library = "bin/Qt5Widgets.dll",
 )
 
 cc_library(
     name = "qt_widgets",
-    hdrs = glob(["QtWidgets/**"]),
-    includes = ["."],
-    linkopts = [
-        "-lQt5Widgets",
-    ],
-    deps = [":qt_core", ":qt_gui"],
+    hdrs = glob(["include/QtWidgets/**"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [":qt_widgets_private"],
 )
 
-cc_library(
-    name = "qt_quick",
-    hdrs = glob(["QtQuick/**"]),
-    includes = ["."],
-    linkopts = [
-        "-lQt5Quick",
-    ],
-    deps = [
-        ":qt_gui",
-        ":qt_qml",
-        ":qt_qml_models",
-    ],
-)
-
-cc_library(
-    name = "qt_qml",
-    hdrs = glob(["QtQml/**"]),
-    includes = ["."],
-    linkopts = [
-        "-lQt5Qml",
-    ],
-    deps = [
-        ":qt_core",
-        ":qt_network",
-    ],
-)
-
-cc_library(
-    name = "qt_qml_models",
-    linkopts = [
-        "-lQt5QmlModels",
-    ],
-    hdrs = glob(
-        ["QtQmlModels/**"],
-    ),
-    includes = ["."],
-)
-
-cc_library(
-    name = "qt_gui",
-    hdrs = glob(["QtGui/**"]),
-    includes = ["."],
-    linkopts = [
-        "-lQt5Gui",
-    ],
-    deps = [":qt_core"],
+cc_import(
+    name = "qt_opengl_private",
+    hdrs = glob(["include/QtOpenGL/**"]),
+    interface_library = "lib/Qt5OpenGL.lib",
+    shared_library = "bin/Qt5OpenGL.dll",
 )
 
 cc_library(
     name = "qt_opengl",
-    hdrs = glob(["QtOpenGL/**"]),
-    includes = ["."],
-    linkopts = ["-lQt5OpenGL"],
+    hdrs = glob(["include/QtOpenGL/**"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [":qt_opengl_private"],
+)
+
+cc_import(
+    name = "qt_gui_private",
+    hdrs = glob(["include/QtGui/**"]),
+    interface_library = "lib/Qt5Gui.lib",
+    shared_library = "bin/Qt5Gui.dll",
 )
 
 cc_library(
-    name = "qt_3d",
-    hdrs = glob([
-        "Qt3DAnimation/**",
-        "Qt3DCore/**",
-        "Qt3DExtras/**",
-        "Qt3DInput/**",
-        "Qt3DLogic/**",
-        "Qt3DQuick/**",
-        "Qt3DQuickAnimation/**",
-        "Qt3DQuickExtras/**",
-        "Qt3DQuickInput/**",
-        "Qt3DQuickRender/**",
-        "Qt3DQuickScene2D/**",
-        "Qt3DRender/**",
-    ]),
-    includes = ["."],
-    linkopts = [
-        "-lQt53DAnimation",
-        "-lQt53DCore",
-        "-lQt53DExtras",
-        "-lQt53DInput",
-        "-lQt53DLogic",
-        "-lQt53DQuick",
-        "-lQt53DQuickAnimation",
-        "-lQt53DQuickExtras",
-        "-lQt53DQuickInput",
-        "-lQt53DQuickRender",
-        "-lQt53DQuickScene2D",
-        "-lQt53DRender",
-    ],
+    name = "qt_gui",
+    hdrs = glob(["include/QtGui/**"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [":qt_gui_private"],
+)
+
+filegroup(
+    name = "uic",
+    srcs = ["bin/uic.exe"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "moc",
+    srcs = ["bin/moc.exe"],
+    visibility = ["//visibility:public"],
 )

--- a/qt.bzl
+++ b/qt.bzl
@@ -27,7 +27,8 @@ def qt_ui_library(name, ui, deps, **kwargs):
         name = "%s_uic" % name,
         srcs = [ui],
         outs = ["ui_%s.h" % ui.split(".")[0]],
-        cmd = "uic $(locations %s) -o $@" % ui,
+        cmd = "$(location @qt//:uic) $(locations %s) -o $@" % ui,
+        tools = ["@qt//:uic"],
     )
 
     native.cc_library(
@@ -107,8 +108,9 @@ def qt_cc_library(name, srcs, hdrs, normal_hdrs = [], deps = None, **kwargs):
             name = moc_name,
             srcs = [hdr],
             outs = [moc_name + ".cc"],
-            cmd = "moc $(location %s) -o $@ -f'%s'" %
+            cmd = "$(location @qt//:moc)  $(location %s) -o $@ -f'%s'" %
                   (hdr, header_path),
+            tools = ["@qt//:moc"],
         )
         _moc_srcs += [":" + moc_name]
 

--- a/readme.md
+++ b/readme.md
@@ -24,9 +24,7 @@ git_repository(
 new_local_repository(
     name = "qt",
     build_file = "@bazel_rules_qt//:qt.BUILD",
-    path = "/usr/include/qt", # May need configuring for your installation
-    # For Qt5 on Ubuntu 16.04
-    # path = "/usr/include/x86_64-linux-gnu/qt5/"
+    path = "C:\\Qt\\5.9.9\\msvc2015_64\\", # May need configuring for your installation
 )
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
-# Bazel rules for Qt [![ci status](https://circleci.com/gh/justbuchanan/bazel_rules_qt.png?circle-token=9077bf6ecc5554e3ddbdc4d3947784460eb1df72)](https://app.circleci.com/pipelines/github/justbuchanan/bazel_rules_qt?branch=master)
+# Bazel rules for Qt [![ci status](https://circleci.com/gh/limdor/bazel_rules_qt.png)](https://app.circleci.com/pipelines/github/limdor/bazel_rules_qt?branch=master)
 
 These bazel rules and BUILD targets make it easy to use Qt from C++ projects built with bazel.
 
-Note that unlike many libraries used through bazel, qt is dynamically linked, meaning that the qt-dependent programs you build with bazel will use the qt libraries installed by the system package manager. Thus the users of your programs will also need to install qt.
+Note that unlike the original bazel_rules_qt, it is not needed to have Qt installed in the system to run your program. The needed dll files are copied to the output folder to make it self contained. However qt is still dynamically linked.
 
 ## Usage
 
@@ -17,7 +17,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "bazel_rules_qt",
-    remote = "https://github.com/justbuchanan/bazel_rules_qt.git",
+    remote = "https://github.com/limdor/bazel_rules_qt.git",
     branch = "master",
 )
 
@@ -62,4 +62,4 @@ cc_binary(
 
 ## Credits
 
-This is a fork of https://github.com/bbreslauer/qt-bazel-example with many modifications.
+This is a fork of https://github.com/justbuchanan/bazel_rules_qt with changes to make it work on Windows.


### PR DESCRIPTION
In order to focus fully on making it work for windows, the support for linux is removed.
Once it is proven that windows is working the plan is to bring the contributions to the original repository.
The original repository at this moment is not supporting windows.
For more information see: https://github.com/justbuchanan/bazel_rules_qt/issues/5